### PR TITLE
Implement the eDisk layer

### DIFF
--- a/Lab5/eDisk.c
+++ b/Lab5/eDisk.c
@@ -157,8 +157,15 @@ enum DRESULT eDisk_WriteSector(
 enum DRESULT eDisk_Format(void){
 // erase all flash from EDISK_ADDR_MIN to EDISK_ADDR_MAX
 // **write this function**
-  
-	
-	
-  return RES_OK;
+  int status;
+  uint32_t erase_address = (uint32_t) EDISK_ADDR_MIN; // start of disk
+  while(erase_address < (uint32_t) EDISK_ADDR_MAX) {
+    status = Flash_Erase(erase_address); // erase 1k block
+    erase_address = erase_address + 1024;
+  }
+  if (status == RES_OK) {
+    return RES_OK;
+  } else {
+      return RES_ERROR;
+  }
 }

--- a/Lab5/eDisk.c
+++ b/Lab5/eDisk.c
@@ -105,9 +105,44 @@ enum DRESULT eDisk_WriteSector(
 // write 512 bytes from RAM (buff) into ROM (disk)
 // you can use Flash_FastWrite or Flash_WriteArray
 // **write this function**
-  
-			
-  return RES_OK;
+        
+    // Step 1: Get write_address
+    uint32_t write_address;
+    write_address = (uint32_t) (EDISK_ADDR_MIN + (512 * sector));
+    // Test if address is out of bounds
+    if (write_address > (uint32_t) EDISK_ADDR_MAX) {
+        return RES_PARERR;
+    }
+
+    // Step 2: Allign 8 bit values to 32bit values to use FLASH_WriteArray()
+    uint32_t alligned_32bit_data[128];
+    uint32_t index_32bit = 0;
+    for (int i = 0; i < 512; i = i + 4) {
+        alligned_32bit_data[index_32bit] = 0;
+        // Byte 1
+        alligned_32bit_data[index_32bit] += buff[i];
+        alligned_32bit_data[index_32bit] = (alligned_32bit_data[index_32bit] << 8);
+        // Byte 2
+        alligned_32bit_data[index_32bit] += buff[i+1];
+        alligned_32bit_data[index_32bit] = (alligned_32bit_data[index_32bit] << 8);
+        // Byte 3
+        alligned_32bit_data[index_32bit] += buff[i+2];
+        alligned_32bit_data[index_32bit] = (alligned_32bit_data[index_32bit] << 8);
+        // Byte 4
+        alligned_32bit_data[index_32bit] += buff[i+3];
+
+        index_32bit++;
+    }
+    
+    // Step 3: Write to flash
+    int status;
+    status = Flash_WriteArray(alligned_32bit_data, write_address, 128);
+    // Flash_Write_Array returns number of succesful writes
+    if (status == 128) {
+        return RES_OK;
+    } else {
+        return RES_ERROR;
+    }
 }
 
 //*************** eDisk_Format ***********

--- a/Lab5/eDisk.c
+++ b/Lab5/eDisk.c
@@ -71,9 +71,20 @@ enum DRESULT eDisk_ReadSector(
 // return RES_PARERR if EDISK_ADDR_MIN + 512*sector > EDISK_ADDR_MAX
 // copy 512 bytes from ROM (disk) into RAM (buff)
 // **write this function**
- 
-			
-  return RES_OK;
+
+    // Step 1: Get address pt
+    volatile uint32_t *read_address_pt;
+    read_address_pt = (volatile uint32_t *) (EDISK_ADDR_MIN + (512 * sector));
+    // Test if address is out of bounds
+    if (read_address_pt > (uint32_t *) EDISK_ADDR_MAX) {
+        return RES_PARERR;
+    }
+    // Step 2: Read memory contents 8bits (1 byte) at a time
+    for (int i = 0; i < 512; i++) {
+        buff[i] = *(read_address_pt + (i * sizeof(uint8_t)));
+    }
+
+    return RES_OK;
 }
 
 //*************** eDisk_WriteSector ***********


### PR DESCRIPTION
Functions used to read/write/format the flash ROM.

* The disk layer partitions the second half of the on-board flash into a solid state disk. The sector size will be 512 bytes. 
* This module provides sector read and write functions. These functions begin with eDisk.